### PR TITLE
Deep History Home Page Resolution

### DIFF
--- a/deepHistory/src/app/app.module.ts
+++ b/deepHistory/src/app/app.module.ts
@@ -1,4 +1,3 @@
-import { RepoComponent } from './repo/repo.component';
 import { NgModule } from "@angular/core";
 import { ReactiveFormsModule, FormsModule } from "@angular/forms";
 import { BrowserModule } from "@angular/platform-browser";
@@ -12,16 +11,17 @@ import { AuthGuard } from "./core/auth.guard";
 import { AuthService } from "./core/auth.service";
 import { UserService } from "./core/user.service";
 import { LoginComponent } from "./login/login.component";
+import { RepoComponent } from "./repo/repo.component";
 import { UserComponent } from "./user/user.component";
 import { UserResolver } from "./user/user.resolver";
-import {HttpClientModule} from '@angular/common/http';
-
+import { HttpClientModule} from '@angular/common/http';
+import { MatGridListModule } from '@angular/material/grid-list';
 import { AppComponent } from "./app.component";
 import { DataService } from "./services/shared-service";
-
 import { MatCardModule } from '@angular/material';
 import { RepositorySearchPipe } from "./pipe/repository-search-pipe";
 import { RepoSharedService } from './services/repo-shared-service';
+
 
 @NgModule({
   declarations: [AppComponent, LoginComponent, RepoComponent, UserComponent, RepositorySearchPipe],
@@ -34,7 +34,8 @@ import { RepoSharedService } from './services/repo-shared-service';
     AngularFireAuthModule, // imports firebase/auth, only needed for auth features
     HttpClientModule,
     MatCardModule,
-    FormsModule
+    FormsModule,
+    MatGridListModule
   ],
   providers: [AuthService, UserService, UserResolver, AuthGuard, DataService, RepoSharedService],
   bootstrap: [AppComponent]

--- a/deepHistory/src/app/app.module.ts
+++ b/deepHistory/src/app/app.module.ts
@@ -14,17 +14,18 @@ import { LoginComponent } from "./login/login.component";
 import { RepoComponent } from "./repo/repo.component";
 import { UserComponent } from "./user/user.component";
 import { UserResolver } from "./user/user.resolver";
-import { HttpClientModule} from '@angular/common/http';
+import { HttpClientModule } from '@angular/common/http';
 import { MatGridListModule } from '@angular/material/grid-list';
 import { AppComponent } from "./app.component";
 import { DataService } from "./services/shared-service";
 import { MatCardModule } from '@angular/material';
 import { RepositorySearchPipe } from "./pipe/repository-search-pipe";
+import { CommitSearchPipe } from "./pipe/commit-search-pipe";
 import { RepoSharedService } from './services/repo-shared-service';
 
 
 @NgModule({
-  declarations: [AppComponent, LoginComponent, RepoComponent, UserComponent, RepositorySearchPipe],
+  declarations: [AppComponent, LoginComponent, RepoComponent, UserComponent, RepositorySearchPipe, CommitSearchPipe],
   imports: [
     BrowserModule,
     ReactiveFormsModule,

--- a/deepHistory/src/app/app.module.ts
+++ b/deepHistory/src/app/app.module.ts
@@ -1,3 +1,4 @@
+import { RepoComponent } from './repo/repo.component';
 import { NgModule } from "@angular/core";
 import { ReactiveFormsModule, FormsModule } from "@angular/forms";
 import { BrowserModule } from "@angular/platform-browser";
@@ -20,9 +21,10 @@ import { DataService } from "./services/shared-service";
 
 import { MatCardModule } from '@angular/material';
 import { RepositorySearchPipe } from "./pipe/repository-search-pipe";
+import { RepoSharedService } from './services/repo-shared-service';
 
 @NgModule({
-  declarations: [AppComponent, LoginComponent, UserComponent, RepositorySearchPipe],
+  declarations: [AppComponent, LoginComponent, RepoComponent, UserComponent, RepositorySearchPipe],
   imports: [
     BrowserModule,
     ReactiveFormsModule,
@@ -34,7 +36,7 @@ import { RepositorySearchPipe } from "./pipe/repository-search-pipe";
     MatCardModule,
     FormsModule
   ],
-  providers: [AuthService, UserService, UserResolver, AuthGuard, DataService],
+  providers: [AuthService, UserService, UserResolver, AuthGuard, DataService, RepoSharedService],
   bootstrap: [AppComponent]
 })
 export class AppModule {}

--- a/deepHistory/src/app/app.routes.ts
+++ b/deepHistory/src/app/app.routes.ts
@@ -4,9 +4,11 @@ import { LoginComponent } from "./login/login.component";
 import { UserComponent } from "./user/user.component";
 import { UserResolver } from "./user/user.resolver";
 import { AuthGuard } from "./core/auth.guard";
+import { RepoComponent } from "./repo/repo.component";
 
 export const rootRouterConfig: Routes = [
   { path: "", redirectTo: "login", pathMatch: "full" },
   { path: "login", component: LoginComponent, canActivate: [AuthGuard] },
-  { path: "user", component: UserComponent, resolve: { data: UserResolver }}
+  { path: "user", component: UserComponent, resolve: { data: UserResolver }},
+  { path: "repo", component: RepoComponent}
 ];

--- a/deepHistory/src/app/core/auth.service.ts
+++ b/deepHistory/src/app/core/auth.service.ts
@@ -3,9 +3,12 @@ import "rxjs/add/operator/toPromise";
 import { AngularFireAuth } from "angularfire2/auth";
 import * as firebase from "firebase/app";
 import { HttpClient } from '@angular/common/http';
+import { GithubApiService } from "../services/github-api-service";
 
 @Injectable()
 export class AuthService {
+
+  githubApiService: GithubApiService = new GithubApiService(this.http);
 
   constructor(public afAuth: AngularFireAuth, private http: HttpClient) {
   }
@@ -13,16 +16,26 @@ export class AuthService {
   // use the Firebase auth service to log in with Github
   doGithubLogin() {
     return new Promise<any>((resolve, reject) => {
-      let provider = new firebase.auth.GithubAuthProvider();
-      this.afAuth.auth.signInWithPopup(provider).then(
-        res => {
-          resolve(res);
-        },
-        err => {
-          console.log(err);
-          reject(err);
+      firebase.auth().onAuthStateChanged(user => {
+        if (user) {
+          this.githubApiService
+            .getUserObjectWithId(user.providerData[0].uid)
+            .subscribe((userObject : any) => {
+              resolve(userObject.login);
+            });
+        } else {
+          let provider = new firebase.auth.GithubAuthProvider();
+          this.afAuth.auth.signInWithPopup(provider).then(
+            res => {
+              resolve(res.additionalUserInfo.username);
+            },
+            err => {
+              console.log(err);
+              reject(err);
+            }
+          );
         }
-      );
+      });
     });
   }
 

--- a/deepHistory/src/app/login/login.component.html
+++ b/deepHistory/src/app/login/login.component.html
@@ -5,6 +5,7 @@
           width=30> Use My Github Account</button>
     <div>
       <page-user hidden></page-user>
+      <page-repo hidden></page-repo>
     </div>
   </div>
 </div>

--- a/deepHistory/src/app/login/login.component.ts
+++ b/deepHistory/src/app/login/login.component.ts
@@ -15,7 +15,7 @@ export class LoginComponent implements OnInit {
 
   tryGithubLogin() {
     this.authService.doGithubLogin().then(res => {
-      this.data.changeValue(res.additionalUserInfo.username);
+      this.data.changeValue(res);
       this.router.navigate(["/user"]);
     });
   }

--- a/deepHistory/src/app/pipe/commit-search-pipe.ts
+++ b/deepHistory/src/app/pipe/commit-search-pipe.ts
@@ -1,0 +1,16 @@
+import { PipeTransform, Pipe } from '@angular/core'
+
+@Pipe({
+  name: 'commitFilter'
+})
+
+export class CommitSearchPipe implements PipeTransform {
+  transform(commit: any[], searchTerm: string): string[] {
+    if (!commit || !searchTerm) {
+      return commit;
+    }
+
+    return commit.filter(commits =>
+      commits.commit.message.toLowerCase().indexOf(searchTerm.toLowerCase()) !== -1);
+  }
+}

--- a/deepHistory/src/app/repo/repo.component.css
+++ b/deepHistory/src/app/repo/repo.component.css
@@ -1,0 +1,72 @@
+@font-face { font-family: 'Nexa Light'; src: url('/src/assets/fonts/Nexa\ Light.otf');}
+
+.header {
+  font-weight: normal;
+  font-size: 250%;
+  font-family: 'Nexa Light';
+  margin-left: 40px;
+  margin-top: 20px;
+}
+
+.repository_page {
+  height: 100vh;
+  width: 100vw;
+}
+
+.btn-previous-page {
+  margin-top: 20px;
+  margin-right: 40px;
+  padding: 3px 20px 3px 20px;
+  border-radius: 10px;
+  background-color: transparent;
+  color: black;
+  background-color: white;
+  border: 1px solid black;
+  font-family: 'Nexa Light';
+  font-size: 150%;
+  position:absolute;
+  top:0;
+  right:0;
+}
+
+.container {
+    height: 10%;
+    width: 100%;
+    text-align: center;
+    padding-bottom: 20px;
+    padding-top: 10px;
+}
+
+.search #textbox {
+    width: 33%;
+    color: black;
+    outline: none;
+    padding: 10px;
+    border: none;
+    border-bottom: 2px solid black;
+    border-top: 2px solid white;
+    margin-bottom: 10px;
+}
+
+.repocards{
+  border-radius: 20px;
+  border: 1px solid black;
+  font-size: 100%;
+}
+
+.cards_container {
+  padding-left: 3%;
+  float: left;
+  height: 70%;
+  width: 40%;
+  text-align: center;
+  margin: 0 auto;
+  overflow-y: scroll;
+  overflow-x: hidden;
+}
+
+::-webkit-scrollbar {
+  background: transparent;
+  width: 0px;
+}
+

--- a/deepHistory/src/app/repo/repo.component.css
+++ b/deepHistory/src/app/repo/repo.component.css
@@ -1,4 +1,7 @@
-@font-face { font-family: 'Nexa Light'; src: url('/src/assets/fonts/Nexa\ Light.otf');}
+@font-face {
+  font-family: 'Nexa Light';
+  src: url('/src/assets/fonts/Nexa\ Light.otf');
+}
 
 .header {
   font-weight: normal;
@@ -24,31 +27,31 @@
   border: 1px solid black;
   font-family: 'Nexa Light';
   font-size: 150%;
-  position:absolute;
-  top:0;
-  right:0;
+  position: absolute;
+  top: 0;
+  right: 0;
 }
 
 .container {
-    height: 10%;
-    width: 100%;
-    text-align: center;
-    padding-bottom: 20px;
-    padding-top: 10px;
+  height: 10%;
+  width: 100%;
+  text-align: center;
+  padding-bottom: 20px;
+  padding-top: 10px;
 }
 
 .search #textbox {
-    width: 33%;
-    color: black;
-    outline: none;
-    padding: 10px;
-    border: none;
-    border-bottom: 2px solid black;
-    border-top: 2px solid white;
-    margin-bottom: 10px;
+  width: 33%;
+  color: black;
+  outline: none;
+  padding: 10px;
+  border: none;
+  border-bottom: 2px solid black;
+  border-top: 2px solid white;
+  margin-bottom: 10px;
 }
 
-.repocards{
+.repocards {
   border-radius: 20px;
   border: 1px solid black;
   font-size: 100%;
@@ -65,8 +68,18 @@
   overflow-x: hidden;
 }
 
+.cards_container_files {
+  padding-left: 3%;
+  float: right;
+  height: 70%;
+  width: 40%;
+  text-align: center;
+  margin: 0 auto;
+  overflow-y: scroll;
+  overflow-x: hidden;
+}
+
 ::-webkit-scrollbar {
   background: transparent;
   width: 0px;
 }
-

--- a/deepHistory/src/app/repo/repo.component.html
+++ b/deepHistory/src/app/repo/repo.component.html
@@ -1,9 +1,14 @@
-<div>
- <ul>
-   <li *ngFor="let commit of commits">
-     <mat-card>
-       {{commit.commit.message}}
-     </mat-card>
-   </li>
- </ul>
+<div class="repository_page">
+  <h1 class="header">Deep History Analytics</h1>
+  <div class="search container" ng-controller="myController">
+    <input type="text" name="query" autocomplete="off" placeholder="Search for a Commit..." onfocus="this.placeholder = ''"
+      onblur="this.placeholder = 'Search for a Commit...'" id="textbox" [(ngModel)]="searchTerm" />
+  </div>
+  <div class="cards_container">
+    <mat-grid-list cols="1" rowHeight="15:1" gutterSize="10">
+      <mat-grid-tile *ngFor="let commit of commits | commitFilter:searchTerm" class="repocards">{{commit.commit.message}}</mat-grid-tile>
+    </mat-grid-list>
+  </div>
+
+  <button type="button" class="btn-previous-page" (click)="returnBack()">Return to Repository Page</button>
 </div>

--- a/deepHistory/src/app/repo/repo.component.html
+++ b/deepHistory/src/app/repo/repo.component.html
@@ -1,0 +1,9 @@
+<div>
+ <ul>
+   <li *ngFor="let commit of commits">
+     <mat-card>
+       {{commit.commit.message}}
+     </mat-card>
+   </li>
+ </ul>
+</div>

--- a/deepHistory/src/app/repo/repo.component.html
+++ b/deepHistory/src/app/repo/repo.component.html
@@ -10,5 +10,12 @@
     </mat-grid-list>
   </div>
 
-  <button type="button" class="btn-previous-page" (click)="returnBack()">Return to Repository Page</button>
+  <div class="cards_container_files">
+    <mat-grid-list cols="1" rowHeight="20:1" gutterSize="2">
+      <mat-grid-tile *ngFor="let file of files" (click)="fileOnClick(file)">{{file.path}}</mat-grid-tile>
+    </mat-grid-list>
+  </div>
+
+  <button type="
+        button" class="btn-previous-page" (click)="returnBack()">Return to Repository Page</button>
 </div>

--- a/deepHistory/src/app/repo/repo.component.ts
+++ b/deepHistory/src/app/repo/repo.component.ts
@@ -1,14 +1,14 @@
-import { Router } from '@angular/router';
-import { HttpClient } from '@angular/common/http';
-import { ActivatedRoute } from '@angular/router';
+import { Router } from "@angular/router";
+import { HttpClient } from "@angular/common/http";
+import { ActivatedRoute } from "@angular/router";
 import { Component, OnInit } from "@angular/core";
-import { RepoSharedService } from '../services/repo-shared-service';
-import { GithubApiService } from '../services/github-api-service';
-import { DataService } from '../services/shared-service';
+import { RepoSharedService } from "../services/repo-shared-service";
+import { GithubApiService } from "../services/github-api-service";
+import { DataService } from "../services/shared-service";
 
 @Component({
-  selector: 'page-repo',
-  templateUrl: 'repo.component.html'
+  selector: "page-repo",
+  templateUrl: "repo.component.html"
 })
 export class RepoComponent implements OnInit {
   loginName: string;
@@ -23,14 +23,15 @@ export class RepoComponent implements OnInit {
     private router: Router,
     private dataService: DataService,
     private repoService: RepoSharedService
-  ) { 
-    this.repoService.current.subscribe(name => this.repoName = name); 
-    this.dataService.current.subscribe(name => this.loginName = name);
+  ) {
+    this.repoService.current.subscribe(name => (this.repoName = name));
+    this.dataService.current.subscribe(name => (this.loginName = name));
   }
 
   display(): void {
-    this.githubApiService.getRepositoryCommits(this.loginName, this.repoName)
-      .forEach( (commit : any) => {
+    this.githubApiService
+      .getRepositoryCommits(this.loginName, this.repoName)
+      .forEach((commit: any) => {
         this.commits = commit;
       });
   }
@@ -38,6 +39,10 @@ export class RepoComponent implements OnInit {
   ngOnInit(): void {
     if (this.repoName !== "default name") {
       this.display();
+      this.githubApiService.getDirectoryStructureForRepo(
+        this.repoName,
+        this.loginName
+      );
     }
   }
 }

--- a/deepHistory/src/app/repo/repo.component.ts
+++ b/deepHistory/src/app/repo/repo.component.ts
@@ -8,7 +8,8 @@ import { DataService } from "../services/shared-service";
 
 @Component({
   selector: "page-repo",
-  templateUrl: "repo.component.html"
+  templateUrl: "repo.component.html",
+  styleUrls: ["repo.component.css"]
 })
 export class RepoComponent implements OnInit {
   loginName: string;
@@ -44,5 +45,9 @@ export class RepoComponent implements OnInit {
         this.loginName
       );
     }
+  }
+
+  returnBack() {
+    this.router.navigate(["/user"]);
   }
 }

--- a/deepHistory/src/app/repo/repo.component.ts
+++ b/deepHistory/src/app/repo/repo.component.ts
@@ -5,6 +5,7 @@ import { Component, OnInit } from "@angular/core";
 import { RepoSharedService } from "../services/repo-shared-service";
 import { GithubApiService } from "../services/github-api-service";
 import { DataService } from "../services/shared-service";
+import { Observable } from "rxjs";
 
 @Component({
   selector: "page-repo",
@@ -17,6 +18,7 @@ export class RepoComponent implements OnInit {
   githubApiService: GithubApiService = new GithubApiService(this.httpClient);
 
   commits: any;
+  files: any;
 
   constructor(
     public route: ActivatedRoute,
@@ -34,17 +36,26 @@ export class RepoComponent implements OnInit {
       .getRepositoryCommits(this.loginName, this.repoName)
       .forEach((commit: any) => {
         this.commits = commit;
+        console.log(this.commits);
       });
+    this.githubApiService
+      .getDirectoryStructureForRepo(this.repoName, this.loginName)
+      .then((res: Observable<Object>) =>
+        res.forEach(filesTree => {
+          this.files = filesTree["tree"];
+        })
+      );
   }
 
   ngOnInit(): void {
     if (this.repoName !== "default name") {
       this.display();
-      this.githubApiService.getDirectoryStructureForRepo(
-        this.repoName,
-        this.loginName
-      );
     }
+  }
+
+  fileOnClick(file: string) {
+    // TODO: pull the contents from the url.
+    window.location.href = file["url"];
   }
 
   returnBack() {

--- a/deepHistory/src/app/repo/repo.component.ts
+++ b/deepHistory/src/app/repo/repo.component.ts
@@ -1,0 +1,43 @@
+import { Router } from '@angular/router';
+import { HttpClient } from '@angular/common/http';
+import { ActivatedRoute } from '@angular/router';
+import { Component, OnInit } from "@angular/core";
+import { RepoSharedService } from '../services/repo-shared-service';
+import { GithubApiService } from '../services/github-api-service';
+import { DataService } from '../services/shared-service';
+
+@Component({
+  selector: 'page-repo',
+  templateUrl: 'repo.component.html'
+})
+export class RepoComponent implements OnInit {
+  loginName: string;
+  repoName: string;
+  githubApiService: GithubApiService = new GithubApiService(this.httpClient);
+
+  commits: any;
+
+  constructor(
+    public route: ActivatedRoute,
+    private httpClient: HttpClient,
+    private router: Router,
+    private dataService: DataService,
+    private repoService: RepoSharedService
+  ) { 
+    this.repoService.current.subscribe(name => this.repoName = name); 
+    this.dataService.current.subscribe(name => this.loginName = name);
+  }
+
+  display(): void {
+    this.githubApiService.getRepositoryCommits(this.loginName, this.repoName)
+      .forEach( (commit : any) => {
+        this.commits = commit;
+      });
+  }
+
+  ngOnInit(): void {
+    console.log("Initializing page with repo: " + this.repoName);
+
+    this.display();
+  }
+}

--- a/deepHistory/src/app/repo/repo.component.ts
+++ b/deepHistory/src/app/repo/repo.component.ts
@@ -36,8 +36,8 @@ export class RepoComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    console.log("Initializing page with repo: " + this.repoName);
-
-    this.display();
+    if (this.repoName !== "default name") {
+      this.display();
+    }
   }
 }

--- a/deepHistory/src/app/repo/repo.component.ts
+++ b/deepHistory/src/app/repo/repo.component.ts
@@ -55,6 +55,11 @@ export class RepoComponent implements OnInit {
 
   fileOnClick(file: string) {
     // TODO: pull the contents from the url.
+    this.githubApiService.getHtmlContentOfFiles(
+      file["url"],
+      this.repoName,
+      this.loginName
+    );
     window.location.href = file["url"];
   }
 

--- a/deepHistory/src/app/services/github-api-service.ts
+++ b/deepHistory/src/app/services/github-api-service.ts
@@ -1,80 +1,104 @@
 import { Injectable } from "@angular/core";
-import { HttpClient } from '@angular/common/http';
-import { Observable } from 'rxjs/Observable';
+import { HttpClient } from "@angular/common/http";
+import { Observable } from "rxjs/Rx";
+import { map } from "rxjs/operators";
 
 @Injectable()
 export class GithubApiService {
-    constructor(private _http: HttpClient) {
-        //empty constructor
-    }
+  shaId: any;
+  constructor(private _http: HttpClient) {
+    //empty constructor
+  }
 
-    public getRepositoryByOwnerAndRepo(owner: string, repo: string): Observable<Object> {
-        const url: string = this._generateRepositoryUrl(owner, repo);
+  public getRepositoryByOwnerAndRepo(
+    owner: string,
+    repo: string
+  ): Observable<Object> {
+    const url: string = this._generateRepositoryUrl(owner, repo);
 
-        return this._http.get(url);
-    }
+    return this._http.get(url);
+  }
 
-    public getRepositoryCommits(owner: string, repo: string): Observable<Object> {
-        const url: string = this._generateRepositoryCommitsUrl(owner, repo);
+  public getRepositoryCommits(owner: string, repo: string): Observable<Object> {
+    const url: string = this._generateRepositoryCommitsUrl(owner, repo);
 
-        return this._http.get(url);
-    }
+    return this._http.get(url);
+  }
 
-    public getUserRepositoryList(owner: string): Promise<string[]> {
-        return this._getUserRepositoryList(owner, 1);
-    }
+  public getUserRepositoryList(owner: string): Promise<string[]> {
+    return this._getUserRepositoryList(owner, 1);
+  }
 
-    public getAuthenticatedUserInfo(): Observable<Object> {
-        const url: string = `https://api.github.com/user`;
+  public getDirectoryStructureForRepo(repo: string, owner: string) {
+    // assuming we get the master branch
+    this.shaId = this.getMasterBranch(owner, repo);
+    console.log(this.shaId);
+    const url = `https://api.github.com/repos/${owner}/${repo}/git/trees/${
+      this.shaId
+    }?recursive=1`;
 
-        return this._http.get(url);
-    }
+    return this._http.get(url); // gets ur the tree of the files in the repo
+  }
 
-    public getUserObjectWithId(id: string) {
-        const url: string = this._generateUserObjectWithIdUrl(id);
+  public getUserObjectWithId(id: string) {
+    const url: string = this._generateUserObjectWithIdUrl(id);
+    return this._http.get(url);
+  }
 
-        return this._http.get(url);
-    }
+  public getMasterBranch(owner: string, repo: string) {
+    const masterBranch = `https://api.github.com/repos/${owner}/${repo}/git/refs/heads/master`;
+    return this._http
+      .get(masterBranch)
+      .pipe(map(response => response["objects"].sha));
+  }
+  public getAuthenticatedUserInfo(): Observable<Object> {
+    const url: string = `https://api.github.com/user`;
 
-    private _getUserRepositoryList(owner: string, page_number: number): Promise<string[]> {
-        return new Promise((resolve, reject) => {
-            let currentArray: any;
-            const url: string = this._generateUserRepositoryUrl(owner, page_number);
+    return this._http.get(url);
+  }
 
-            this._http.get<string[]>(url).forEach(
-                repo => {
-                    currentArray = repo;
-                }
-            ).then(
-                res => {
-                    if (currentArray.length == 100) {
-                        this._getUserRepositoryList(owner, page_number + 1).then(res2 => {
-                            resolve(currentArray.concat(res2));
-                        });
-                    } else {
-                        resolve(currentArray);
-                    }
-                },
-                err => {
-                    console.log("Error getting repo list", err);
-                    reject(err);
-                }
-            )
-        });
-    }
+  private _getUserRepositoryList(
+    owner: string,
+    page_number: number
+  ): Promise<string[]> {
+    return new Promise((resolve, reject) => {
+      let currentArray: any;
+      const url: string = this._generateUserRepositoryUrl(owner, page_number);
 
-    private _generateRepositoryUrl(owner: string, repo: string) {
-        return `https://api.github.com/repos/${owner}/${repo}`;
-    }
+      this._http
+        .get<string[]>(url)
+        .forEach(repo => {
+          currentArray = repo;
+        })
+        .then(
+          res => {
+            if (currentArray.length == 100) {
+              this._getUserRepositoryList(owner, page_number + 1).then(res2 => {
+                resolve(currentArray.concat(res2));
+              });
+            } else {
+              resolve(currentArray);
+            }
+          },
+          err => {
+            console.log("Error getting repo list", err);
+            reject(err);
+          }
+        );
+    });
+  }
 
-    private _generateRepositoryCommitsUrl(owner: string, repo: string) {
-        return `https://api.github.com/repos/${owner}/${repo}/commits`;
-    }
+  private _generateUserRepositoryUrl(owner: string, page_number: number) {
+    return `https://api.github.com/users/${owner}/repos?per_page=100\&page=${page_number}`;
+  }
+  private _generateUserObjectWithIdUrl(id: string) {
+    return `https://api.github.com/user/${id}`;
+  }
+  private _generateRepositoryUrl(owner: string, repo: string) {
+    return `https://api.github.com/repos/${owner}/${repo}`;
+  }
 
-    private _generateUserRepositoryUrl(owner: string, page_number: number) {
-        return `https://api.github.com/users/${owner}/repos?per_page=100\&page=${page_number}`;
-    }
-    private _generateUserObjectWithIdUrl(id: string) {
-        return `https://api.github.com/user/${id}`;
-    }
+  private _generateRepositoryCommitsUrl(owner: string, repo: string) {
+    return `https://api.github.com/repos/${owner}/${repo}/commits`;
+  }
 }

--- a/deepHistory/src/app/services/github-api-service.ts
+++ b/deepHistory/src/app/services/github-api-service.ts
@@ -67,6 +67,12 @@ export class GithubApiService {
     return this._http.get(url);
   }
 
+  /**
+   * Sends a promise back to caller containing the list of ALL repos from the user. 
+   * 
+   * @param owner                     login github name of wanted user              : string
+   * @param page_number               the current page_number, that starts from 1   : number
+   */
   private _getUserRepositoryList(
     owner: string,
     page_number: number
@@ -78,15 +84,18 @@ export class GithubApiService {
       this._http
         .get<string[]>(url)
         .forEach(repo => {
+          //repo here is a LIST of arrays
           currentArray = repo;
         })
-        .then(
+        .then(  //array is resolved in then 
           res => {
+            //If length is 100, there is a possibility of another page, hence concatenate the
+            //current array with a recursive call (increase in page number)
             if (currentArray.length == 100) {
               this._getUserRepositoryList(owner, page_number + 1).then(res2 => {
                 resolve(currentArray.concat(res2));
               });
-            } else {
+            } else {  //Gets here when we are at the last possible page of repos
               resolve(currentArray);
             }
           },

--- a/deepHistory/src/app/services/github-api-service.ts
+++ b/deepHistory/src/app/services/github-api-service.ts
@@ -30,6 +30,12 @@ export class GithubApiService {
         return this._http.get(url);
     }
 
+    public getUserObjectWithId(id: string) {
+        const url: string = this._generateUserObjectWithIdUrl(id);
+
+        return this._http.get(url);
+    }
+
     private _getUserRepositoryList(owner: string, page_number: number): Promise<string[]> {
         return new Promise((resolve, reject) => {
             let currentArray: any;
@@ -67,5 +73,8 @@ export class GithubApiService {
 
     private _generateUserRepositoryUrl(owner: string, page_number: number) {
         return `https://api.github.com/users/${owner}/repos?per_page=100\&page=${page_number}`;
+    }
+    private _generateUserObjectWithIdUrl(id: string) {
+        return `https://api.github.com/user/${id}`;
     }
 }

--- a/deepHistory/src/app/services/repo-shared-service.ts
+++ b/deepHistory/src/app/services/repo-shared-service.ts
@@ -1,9 +1,9 @@
 import { Injectable } from "@angular/core";
 import { BehaviorSubject } from "rxjs";
 
-//This is for ONLY login to user and repo
+//This is ONLY for user to repo
 @Injectable()
-export class DataService {
+export class RepoSharedService {
     private source = new BehaviorSubject('default name');
     current = this.source.asObservable();
 

--- a/deepHistory/src/app/user/user.component.html
+++ b/deepHistory/src/app/user/user.component.html
@@ -8,11 +8,14 @@
     <div class="cards cards_container">
       <ul class="repos" id="repocolumn">
         <li *ngFor="let repo of repos | repoFilter:searchTerm">
-          <mat-card class="repocards" title={{repo.name}}>{{repo.name}}</mat-card>
+          <mat-card class="repocards" title={{repo.name}} (click)="cardOnClick(repo.name)">{{repo.name}}</mat-card>
         </li>
       </ul>
     </div>
 
   <button type="button" class="btn-logout" (click)="logout()">Logout</button>
 
+  <div>
+    <page-repo hidden></page-repo>
+  </div>
 </div>

--- a/deepHistory/src/app/user/user.component.html
+++ b/deepHistory/src/app/user/user.component.html
@@ -5,12 +5,10 @@
       <input type="text" name="query" autocomplete="off" placeholder="Search for a Repository..." onfocus="this.placeholder = ''"
       onblur="this.placeholder = 'Search for a Repository...'" id="textbox" [(ngModel)]="searchTerm"/>
     </div>
-    <div class="cards cards_container">
-      <ul class="repos" id="repocolumn">
-        <li *ngFor="let repo of repos | repoFilter:searchTerm">
-          <mat-card class="repocards" title={{repo.name}} (click)="cardOnClick(repo.name)">{{repo.name}}</mat-card>
-        </li>
-      </ul>
+    <div class="cards_container">
+        <mat-grid-list cols="3" rowHeight="2.5:1" gutterSize="10">
+          <mat-grid-tile *ngFor="let repo of repos | repoFilter:searchTerm" class="repocards" title={{repo.name}} (click)="cardOnClick(repo.name)" >{{repo.name}}</mat-grid-tile>
+        </mat-grid-list>
     </div>
 
   <button type="button" class="btn-logout" (click)="logout()">Logout</button>

--- a/deepHistory/src/app/user/user.component.ts
+++ b/deepHistory/src/app/user/user.component.ts
@@ -64,7 +64,7 @@ export class UserComponent implements OnInit {
 
   tryGithubLogin() {
     this.authService.doGithubLogin().then(res => {
-      this.data.changeValue(res.additionalUserInfo.username);
+      this.data.changeValue(res);
       this.setup();
     },
     err => {

--- a/deepHistory/src/app/user/user.component.ts
+++ b/deepHistory/src/app/user/user.component.ts
@@ -8,6 +8,7 @@ import { UserModel } from "../core/user.model";
 import { HttpClient } from "@angular/common/http";
 import { GithubApiService } from "../services/github-api-service";
 import { DataService } from "../services/shared-service";
+import { RepoSharedService } from "../services/repo-shared-service";
 
 @Component({
   selector: "page-user",
@@ -28,6 +29,7 @@ export class UserComponent implements OnInit {
     private location: Location,
     private httpClient: HttpClient,
     private data: DataService,
+    private repoData: RepoSharedService,
     private router: Router
   ) { this.data.current.subscribe(name => this.loginName = name); }
 
@@ -80,5 +82,10 @@ export class UserComponent implements OnInit {
         console.log("Logout error", error);
       }
     );
+  }
+
+  cardOnClick(repoName: string) {
+    this.repoData.changeValue(repoName);
+    this.router.navigate(["/repo"]);
   }
 }

--- a/deepHistory/src/app/user/user.scss
+++ b/deepHistory/src/app/user/user.scss
@@ -56,26 +56,25 @@ ul {
   list-style-type: none;
   font-family: 'Nexa Light';
 }
-
-.repocards {
-  max-width:100%;
-  min-width: 100%;
+.repocards{
   border-radius: 20px;
   border: 1px solid black;
-  padding: 50px 2px 50px 2px;
-  text-align: center;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  font-size: 200%;
+}
+.grid_text{
+  font-size: 150%;
 }
 
-.cards {
-  height: 50%;
-  max-width: 50%;
-  overflow-y: scroll;
-  overflow-x: hidden;
-}
+// .repocards {
+//   width: 300px;
+//   border-radius: 20px;
+//   border: 1px solid black;
+//   padding: 50px 2px 50px 2px;
+//   text-align: center;
+//   white-space: nowrap;
+//   overflow: hidden;
+//   text-overflow: ellipsis;
+//   font-size: 200%;
+// }
 
 .cards_container {
   align-items: center;
@@ -84,6 +83,8 @@ ul {
   width: 65%;
   text-align: center;
   margin: 0 auto;
+  overflow-y: scroll;
+  overflow-x: hidden;
 }
 
 ::-webkit-scrollbar {
@@ -91,11 +92,9 @@ ul {
   width: 0px;
 }
 
-#repocolumn{
-    display: grid;
-    grid-template-areas: "a a a";
-    grid-gap: 1em;
-    // grid-auto-rows: 100px;
-
-}
+// #repocolumn{
+//     display: grid;
+//     grid-template-areas: "a a a";
+//     grid-gap: 1em;
+// }
 

--- a/deepHistory/src/app/user/user.scss
+++ b/deepHistory/src/app/user/user.scss
@@ -10,6 +10,7 @@
 
 .repositorypage {
   height: 100vh;
+  width: 100vw;
 }
 
 .container {
@@ -19,7 +20,6 @@
     height: 10%;
     width: 100%;
     text-align: center;
-    
     padding-bottom: 20px;
     padding-top: 10px;
 }
@@ -58,8 +58,8 @@ ul {
 }
 
 .repocards {
-  max-width: 300px;
-  min-width: 300px;
+  max-width:100%;
+  min-width: 100%;
   border-radius: 20px;
   border: 1px solid black;
   padding: 50px 2px 50px 2px;
@@ -72,19 +72,18 @@ ul {
 
 .cards {
   height: 50%;
+  max-width: 50%;
   overflow-y: scroll;
+  overflow-x: hidden;
 }
 
 .cards_container {
   align-items: center;
   justify-content: center;
   height: 70%;
-  width: 60%;
+  width: 65%;
   text-align: center;
   margin: 0 auto;
-  
-  padding-bottom: 10px;
-  padding-top: 10px;
 }
 
 ::-webkit-scrollbar {
@@ -95,7 +94,8 @@ ul {
 #repocolumn{
     display: grid;
     grid-template-areas: "a a a";
-    grid-gap: 70px;
-    grid-auto-rows: 100px;
+    grid-gap: 1em;
+    // grid-auto-rows: 100px;
+
 }
 


### PR DESCRIPTION
Front end fixes including: mat-grid instead of mat-cards used to display repository names, cards now scale to window size, containers are now using parent's size relative to window height and width, cards redirect to individual repository page. Commit messages now are displayed on cards and there is a search filter option for this. Able to return to repository page with button. 

Back end changes including: /repo page created, passing repository name without url, redirect from cards to /repo where commits are displayed, authentication is remembered - eliminates constant authentication during refreshes. New pipe for commit pages created.

Pair programmed with @gesonchong 
